### PR TITLE
Fixed birthdayCommand bugs

### DIFF
--- a/src/main/java/seedu/address/logic/commands/BirthdayCommand.java
+++ b/src/main/java/seedu/address/logic/commands/BirthdayCommand.java
@@ -15,7 +15,7 @@ public class BirthdayCommand extends Command {
             + ": Gives a list of all employees who have birthdays in the given month.\n"
             + "Parameters (Optional): "
             + PREFIX_MONTH + "MONTH";
-    public static final String MESSAGE_SUCCESS = Messages.MESSAGE_LIST_SUCCESS;
+    public static final String MESSAGE_SUCCESS = Messages.MESSAGE_LIST_SUCCESS + " in the month of ";
     public static final String MESSAGE_FAILURE = Messages.MESSAGE_BIRTHDAY_FAILURE;
     private final MatchingBirthdayPredicate predicate;
 
@@ -38,7 +38,9 @@ public class BirthdayCommand extends Command {
         if (model.getFilteredPersonList().isEmpty()) {
             return new CommandResult(MESSAGE_FAILURE);
         }
-        return new CommandResult(String.format(MESSAGE_SUCCESS, model.getFilteredPersonList().size()));
+
+        return new CommandResult(String.format(MESSAGE_SUCCESS, model.getFilteredPersonList().size())
+                + predicate.toString());
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/BirthdayCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/BirthdayCommandParser.java
@@ -38,6 +38,7 @@ public class BirthdayCommandParser implements Parser<BirthdayCommand> {
         if (!arePrefixesPresent(argMultimap, PREFIX_MONTH)) {
             throw new ParseException(Messages.MESSAGE_INVALID_MONTH_PREFIX);
         } else {
+            argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_MONTH);
             List<Month> monthList = parseBirthday(argMultimap.getValue(PREFIX_MONTH).get());
             MatchingBirthdayPredicate predicate = new MatchingBirthdayPredicate(monthList);
             return new BirthdayCommand(predicate);
@@ -46,20 +47,16 @@ public class BirthdayCommandParser implements Parser<BirthdayCommand> {
 
     /**
      * Parses a list of months given
-     * @param arg Months as strings
+     * @param args Months as strings
      * @return a list of Months
      */
-    public List<Month> parseBirthday(String arg) throws ParseException {
-        arg = arg.trim();
+    private List<Month> parseBirthday(String args) throws ParseException {
+        args = args.trim();
         List<Month> monthList = new ArrayList<>();
-        String[] args = arg.split(",");
-        for (String s : args) {
-            try {
-                int month = Integer.parseInt(s);
-                monthList.add(new Month(month));
-            } catch (Exception e) {
-                throw new ParseException(Month.INVALID_MONTH);
-            }
+        String[] months = args.split(",");
+        for (String month : months) {
+            int monthValue = ParserUtil.parseMonth(month);
+            monthList.add(new Month(monthValue));
         }
         return monthList;
     }

--- a/src/main/java/seedu/address/model/person/MatchingBirthdayPredicate.java
+++ b/src/main/java/seedu/address/model/person/MatchingBirthdayPredicate.java
@@ -42,4 +42,17 @@ public class MatchingBirthdayPredicate implements Predicate<Person> {
     public boolean test(Person person) {
         return this.month.contains(person.getDob().getMonth());
     }
+
+    @Override
+    public String toString() {
+        StringBuilder message = new StringBuilder();
+        for (int i = 0; i < month.size(); i++) {
+            if (i == month.size() - 1) {
+                message.append(month.get(i).getMonthName());
+            } else {
+                message.append(month.get(i).getMonthName()).append(",");
+            }
+        }
+        return message.toString();
+    }
 }

--- a/src/main/java/seedu/address/model/person/Month.java
+++ b/src/main/java/seedu/address/model/person/Month.java
@@ -1,6 +1,5 @@
 package seedu.address.model.person;
 
-import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
@@ -21,15 +20,19 @@ public class Month {
     public static final String INVALID_MONTH = "Invalid month(s) provided.";
 
     public final int month;
+    public final String monthName;
+    public final String[] monthNames = {
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+        "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
 
     /**
      * Constructs an {@code Month}
      * @param monthValue the integer representation of the intended month.
      */
     public Month(int monthValue) {
-        requireNonNull(monthValue);
         checkArgument(monthValue > 0 && monthValue < 13, INVALID_MONTH);
         month = monthValue;
+        monthName = monthNames[monthValue - 1];
     }
 
     /**
@@ -82,6 +85,10 @@ public class Month {
 
     public int getMonthValue() {
         return month;
+    }
+
+    public String getMonthName() {
+        return monthName;
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/BirthdayCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/BirthdayCommandTest.java
@@ -37,8 +37,8 @@ public class BirthdayCommandTest {
         MatchingBirthdayPredicate matchingBirthdayPredicate = new MatchingBirthdayPredicate(monthList);
         expectedFilteredModel.updateFilteredPersonList(matchingBirthdayPredicate);
         assertCommandSuccess(new BirthdayCommand(matchingBirthdayPredicate), model,
-                String.format(MESSAGE_SUCCESS, expectedFilteredModel.getFilteredPersonList().size()),
-                        expectedFilteredModel);
+                String.format(MESSAGE_SUCCESS, expectedFilteredModel.getFilteredPersonList().size())
+                        + "Feb", expectedFilteredModel);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/BirthdayCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/BirthdayCommandParserTest.java
@@ -35,6 +35,16 @@ public class BirthdayCommandParserTest {
     }
 
     @Test
+    public void parse_invalidMultipleArgs_exceptionThrown() {
+        assertThrows(ParseException.class, () -> parser.parse(" m/1,-1"));
+    }
+
+    @Test
+    public void duplicatePrefix_exceptionThrown() {
+        assertThrows(ParseException.class, () -> parser.parse(" m/1 m/2"));
+    }
+
+    @Test
     public void parse_noArgs_returnsBirthdayCommand() throws ParseException {
         List<Month> monthList = new ArrayList<>();
         monthList.add(new Month(LocalDate.now().getMonthValue()));

--- a/src/test/java/seedu/address/model/person/MatchingBirthdayPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/MatchingBirthdayPredicateTest.java
@@ -73,4 +73,14 @@ public class MatchingBirthdayPredicateTest {
         MatchingBirthdayPredicate predicate2 = new MatchingBirthdayPredicate(monthList2);
         assertNotEquals(predicate1, predicate2);
     }
+
+    @Test
+    public void stringRep_success() {
+        List<Month> monthList1 = new ArrayList<>();
+        monthList1.add(new Month(2));
+        monthList1.add(new Month(3));
+        MatchingBirthdayPredicate predicate1 = new MatchingBirthdayPredicate(monthList1);
+
+        assertEquals(predicate1.toString(), "Feb,Mar");
+    }
 }

--- a/src/test/java/seedu/address/model/person/MonthTest.java
+++ b/src/test/java/seedu/address/model/person/MonthTest.java
@@ -75,4 +75,10 @@ public class MonthTest {
     public void execute_validMonth() {
         assertTrue(Month.isValidMonth(VALID_MONTH));
     }
+
+    @Test
+    public void execute_getMonthName() {
+        Month testMonth = new Month(1);
+        assertEquals(testMonth.getMonthName(), "Jan");
+    }
 }


### PR DESCRIPTION
Modification of BirthdayCommand, BirthdayCommandParser, Month, ParserUtil

The current codebase does not handle multiple month inputs and multiple prefixes properly. Furthermore, the current success message for BirthdayCommand does not reflect the name of the inquired months.

Hence, I have made the necessary implementations and test cases.