### PR TITLE
Modified email validation regex

### DIFF
--- a/Exported_CSVs/testExport.csv
+++ b/Exported_CSVs/testExport.csv
@@ -1,8 +1,8 @@
 Name,Phone,Email,Address,Salary,Claim Budget,DOB,Department,Leave
-Alice Pauline,94351253,alice@example.com,"123, Jurong West Ave 6, #08-111",10000,5000,2000-01-01,Engineering,"Jan, Feb, Mar, Apr, Jun, Aug, Oct, Dec"
-Benson Meier,98765432,johnd@example.com,"311, Clementi Ave 2, #02-25",100,5,1997-05-05,Sales,"Feb, Apr, Jun, Aug, Oct, Dec"
-Carl Kurz,95352563,heinz@example.com,wall street,1000000000000,500000,1991-12-31,Executive,"Apr, Jun, Aug, Dec"
-Daniel Meier,87652533,cornelia@example.com,10th street,23232323232,19191919,1969-07-27,Marketing,"Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec"
-Elle Meyer,9482224,werner@example.com,michegan ave,3000,200,1999-06-17,HR,Dec
-Fiona Kunz,9482427,lydia@example.com,little tokyo,100000,1,2002-02-27,Finance,Jul
-George Best,9482442,anna@example.com,4th street,10000,5000,2005-09-30,Engineering,"Jan, Feb, Mar, Apr, May, Jun"
+Alice Pauline,94351253,alice@gmail.com,"123, Jurong West Ave 6, #08-111",10000,5000,2000-01-01,Engineering,"Jan, Feb, Mar, Apr, Jun, Aug, Oct, Dec"
+Benson Meier,98765432,johnd@gmail.com,"311, Clementi Ave 2, #02-25",100,5,1997-05-05,Sales,"Feb, Apr, Jun, Aug, Oct, Dec"
+Carl Kurz,95352563,heinz@gmail.com,wall street,1000000000000,500000,1991-12-31,Executive,"Apr, Jun, Aug, Dec"
+Daniel Meier,87652533,cornelia@gmail.com,10th street,23232323232,19191919,1969-07-27,Marketing,"Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec"
+Elle Meyer,9482224,werner@gmail.com,michegan ave,3000,200,1999-06-17,HR,Dec
+Fiona Kunz,9482427,lydia@gmail.com,little tokyo,100000,1,2002-02-27,Finance,Jul
+George Best,9482442,anna@gmail.com,4th street,10000,5000,2005-09-30,Engineering,"Jan, Feb, Mar, Apr, May, Jun"

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -21,17 +21,11 @@ public class Email {
             + "    - end with a domain label at least 2 characters long\n"
             + "    - have each domain label start and end with alphanumeric characters\n"
             + "    - have each domain label consist of alphanumeric characters, separated only by hyphens, if any.";
-    // alphanumeric and special characters
-    private static final String ALPHANUMERIC_NO_UNDERSCORE = "[^\\W_]+"; // alphanumeric characters except underscore
-    private static final String LOCAL_PART_REGEX = "^" + ALPHANUMERIC_NO_UNDERSCORE + "([" + SPECIAL_CHARACTERS + "]"
-            + ALPHANUMERIC_NO_UNDERSCORE + ")*";
-    private static final String DOMAIN_PART_REGEX = ALPHANUMERIC_NO_UNDERSCORE
-            + "(-" + ALPHANUMERIC_NO_UNDERSCORE + ")*";
-    private static final String DOMAIN_LAST_PART_REGEX = "(" + DOMAIN_PART_REGEX + "){2,}$"; // At least two chars
-    private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)*" + DOMAIN_LAST_PART_REGEX;
-    public static final String VALIDATION_REGEX = LOCAL_PART_REGEX + "@" + DOMAIN_REGEX;
 
     public final String value;
+    // Validation Regex for Email
+    private static final String VALIDATION_REGEX = "\\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}\\b";
+
 
     /**
      * Constructs an {@code Email}.

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -15,17 +15,17 @@ public class Email {
             + "1. The local-part should only contain alphanumeric characters and these special characters, excluding "
             + "the parentheses, (" + SPECIAL_CHARACTERS + "). The local-part may not start or end with any special "
             + "characters.\n"
-            + "2. This is followed by a '@' and then a domain name. The domain name is made up of domain labels "
-            + "separated by periods.\n"
-            + "The domain name must:\n"
-            + "    - end with a domain label at least 2 characters long\n"
-            + "    - have each domain label start and end with alphanumeric characters\n"
-            + "    - have each domain label consist of alphanumeric characters, separated only by hyphens, if any.";
+            + "2. This is followed by a '@' and then the domain name, which is gmail.com.\n"
+            + "The domain name can only be gmail.com as only company emails are allowed to be "
+            + "entered into the system.";
+
+    private static final String ALPHANUMERIC_NO_UNDERSCORE = "[^\\W_]+"; // alphanumeric characters except underscore
+    private static final String LOCAL_PART_REGEX = "^" + ALPHANUMERIC_NO_UNDERSCORE + "([" + SPECIAL_CHARACTERS + "]"
+            + ALPHANUMERIC_NO_UNDERSCORE + ")*";
+    private static final String DOMAIN_REGEX = "gmail\\.com$";
+    public static final String VALIDATION_REGEX = LOCAL_PART_REGEX + "@" + DOMAIN_REGEX;
 
     public final String value;
-    // Validation Regex for Email
-    private static final String VALIDATION_REGEX = "\\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}\\b";
-
 
     /**
      * Constructs an {@code Email}.

--- a/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
@@ -2,12 +2,12 @@
   "persons": [ {
     "name": "Valid Person",
     "phone": "9482424",
-    "email": "hans@example.com",
+    "email": "hans@gmail.com",
     "address": "4th street"
   }, {
     "name": "Person With Invalid Phone Field",
     "phone": "948asdf2424",
-    "email": "hans@example.com",
+    "email": "hans@gmail.com",
     "address": "4th street"
   } ]
 }

--- a/src/test/data/JsonAddressBookStorageTest/invalidPersonAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidPersonAddressBook.json
@@ -2,7 +2,7 @@
   "persons": [ {
     "name": "Person with invalid name field: Ha!ns Mu@ster",
     "phone": "9482424",
-    "email": "hans@example.com",
+    "email": "hans@gmail.com",
     "address": "4th street"
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -3,7 +3,7 @@
     {
       "name": "Alice Pauline",
       "phone": "94351253",
-      "email": "alice@example.com",
+      "email": "alice@gmail.com",
       "address": "123, Jurong West Ave 6, #08-111",
       "salary": "100000",
       "claimBudget": "1",
@@ -14,7 +14,7 @@
     {
       "name": "Alice Pauline",
       "phone": "94351253",
-      "email": "pauline@example.com",
+      "email": "pauline@gmail.com",
       "address": "123, Jurong West Ave 6, #08-111",
       "salary": "100000",
       "claimBudget": "1",

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -4,7 +4,7 @@
     {
       "name": "Alice Pauline",
       "phone": "94351253",
-      "email": "alice@example.com",
+      "email": "alice@gmail.com",
       "address": "123, Jurong West Ave 6, #08-111",
       "salary": "10000",
       "claimBudget": "5000",
@@ -15,7 +15,7 @@
     {
       "name": "Benson Meier",
       "phone": "98765432",
-      "email": "johnd@example.com",
+      "email": "johnd@gmail.com",
       "address": "311, Clementi Ave 2, #02-25",
       "salary": "100",
       "claimBudget": "5",
@@ -26,7 +26,7 @@
     {
       "name": "Carl Kurz",
       "phone": "95352563",
-      "email": "heinz@example.com",
+      "email": "heinz@gmail.com",
       "address": "wall street",
       "salary": "1000000000000",
       "claimBudget": "500000",
@@ -37,7 +37,7 @@
     {
       "name": "Daniel Meier",
       "phone": "87652533",
-      "email": "cornelia@example.com",
+      "email": "cornelia@gmail.com",
       "address": "10th street",
       "salary": "23232323232",
       "claimBudget": "19191919",
@@ -48,7 +48,7 @@
     {
       "name": "Elle Meyer",
       "phone": "9482224",
-      "email": "werner@example.com",
+      "email": "werner@gmail.com",
       "address": "michegan ave",
       "salary": "3000",
       "claimBudget": "200",
@@ -59,7 +59,7 @@
     {
       "name": "Fiona Kunz",
       "phone": "9482427",
-      "email": "lydia@example.com",
+      "email": "lydia@gmail.com",
       "address": "little tokyo",
       "salary": "100000",
       "claimBudget": "1",
@@ -70,7 +70,7 @@
     {
       "name": "George Best",
       "phone": "9482442",
-      "email": "anna@example.com",
+      "email": "anna@gmail.com",
       "address": "4th street",
       "salary": "10000",
       "claimBudget": "5000",

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -35,8 +35,8 @@ public class CommandTestUtil {
     public static final String VALID_NAME_BOB = "Bob Choo";
     public static final String VALID_PHONE_AMY = "11111111";
     public static final String VALID_PHONE_BOB = "22222222";
-    public static final String VALID_EMAIL_AMY = "amy@example.com";
-    public static final String VALID_EMAIL_BOB = "bob@example.com";
+    public static final String VALID_EMAIL_AMY = "amy@gmail.com";
+    public static final String VALID_EMAIL_BOB = "bob@gmail.com";
     public static final String VALID_ADDRESS_AMY = "Block 312, Amy Street 1";
     public static final String VALID_ADDRESS_BOB = "Block 123, Bobby Street 3";
     public static final String VALID_SALARY = "10000";

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -30,7 +30,7 @@ public class ParserUtilTest {
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_PHONE = "123456";
     private static final String VALID_ADDRESS = "123 Main Street #0505";
-    private static final String VALID_EMAIL = "rachel@example.com";
+    private static final String VALID_EMAIL = "rachel@gmail.com";
     private static final String VALID_TAG_1 = "friend";
     private static final String VALID_TAG_2 = "neighbour";
 

--- a/src/test/java/seedu/address/model/person/EmailTest.java
+++ b/src/test/java/seedu/address/model/person/EmailTest.java
@@ -36,43 +36,41 @@ public class EmailTest {
 
         // invalid parts
         assertFalse(Email.isValidEmail("peterjack@-")); // invalid domain name
-        assertFalse(Email.isValidEmail("peterjack@exam_ple.com")); // underscore in domain name
-        assertFalse(Email.isValidEmail("peter jack@example.com")); // spaces in local part
-        assertFalse(Email.isValidEmail("peterjack@exam ple.com")); // spaces in domain name
-        assertFalse(Email.isValidEmail(" peterjack@example.com")); // leading space
-        assertFalse(Email.isValidEmail("peterjack@example.com ")); // trailing space
-        assertFalse(Email.isValidEmail("peterjack@@example.com")); // double '@' symbol
-        assertFalse(Email.isValidEmail("peter@jack@example.com")); // '@' symbol in local part
-        assertFalse(Email.isValidEmail("-peterjack@example.com")); // local part starts with a hyphen
-        assertFalse(Email.isValidEmail("peterjack-@example.com")); // local part ends with a hyphen
-        assertFalse(Email.isValidEmail("peter..jack@example.com")); // local part has two consecutive periods
-        assertFalse(Email.isValidEmail("peterjack@example@com")); // '@' symbol in domain name
-        assertFalse(Email.isValidEmail("peterjack@.example.com")); // domain name starts with a period
-        assertFalse(Email.isValidEmail("peterjack@example.com.")); // domain name ends with a period
-        assertFalse(Email.isValidEmail("peterjack@-example.com")); // domain name starts with a hyphen
-        assertFalse(Email.isValidEmail("peterjack@example.com-")); // domain name ends with a hyphen
-        assertFalse(Email.isValidEmail("peterjack@example.c")); // top level domain has less than two chars
+        assertFalse(Email.isValidEmail("e1234567@u.nus.edu")); // invalid domain name (no .com)
+        assertFalse(Email.isValidEmail("peterjack@example.com")); // underscore in domain name (not gmail.com)
+        assertFalse(Email.isValidEmail("peterjack@gm_ail.com")); // underscore in domain name
+        assertFalse(Email.isValidEmail("peter jack@gmail.com")); // spaces in local part
+        assertFalse(Email.isValidEmail("peterjack@gma il.com")); // spaces in domain name
+        assertFalse(Email.isValidEmail(" peterjack@gmail.com")); // leading space
+        assertFalse(Email.isValidEmail("peterjack@gmail.com ")); // trailing space
+        assertFalse(Email.isValidEmail("peterjack@@gmail.com")); // double '@' symbol
+        assertFalse(Email.isValidEmail("peter@jack@gmail.com")); // '@' symbol in local part
+        assertFalse(Email.isValidEmail("-peterjack@gmail.com")); // local part starts with a hyphen
+        assertFalse(Email.isValidEmail("peterjack-@gmail.com")); // local part ends with a hyphen
+        assertFalse(Email.isValidEmail("peter..jack@gmail.com")); // local part has two consecutive periods
+        assertFalse(Email.isValidEmail("peterjack@gmail@com")); // '@' symbol in domain name
+        assertFalse(Email.isValidEmail("peterjack@.gmail.com")); // domain name starts with a period
+        assertFalse(Email.isValidEmail("peterjack@gmail.com.")); // domain name ends with a period
+        assertFalse(Email.isValidEmail("peterjack@-gmail.com")); // domain name starts with a hyphen
+        assertFalse(Email.isValidEmail("peterjack@gmail.com-")); // domain name ends with a hyphen
+        assertFalse(Email.isValidEmail("peterjack@gmail.c")); // top level domain has less than two chars
 
         // valid email
-        assertTrue(Email.isValidEmail("PeterJack_1190@example.com")); // underscore in local part
-        assertTrue(Email.isValidEmail("PeterJack.1190@example.com")); // period in local part
-        assertTrue(Email.isValidEmail("PeterJack+1190@example.com")); // '+' symbol in local part
-        assertTrue(Email.isValidEmail("PeterJack-1190@example.com")); // hyphen in local part
-        assertTrue(Email.isValidEmail("a@bc")); // minimal
-        assertTrue(Email.isValidEmail("test@localhost")); // alphabets only
-        assertTrue(Email.isValidEmail("123@145")); // numeric local part and domain name
-        assertTrue(Email.isValidEmail("a1+be.d@example1.com")); // mixture of alphanumeric and special characters
-        assertTrue(Email.isValidEmail("peter_jack@very-very-very-long-example.com")); // long domain name
-        assertTrue(Email.isValidEmail("if.you.dream.it_you.can.do.it@example.com")); // long local part
-        assertTrue(Email.isValidEmail("e1234567@u.nus.edu")); // more than one period in domain
+        assertTrue(Email.isValidEmail("PeterJack_1190@gmail.com")); // underscore in local part
+        assertTrue(Email.isValidEmail("PeterJack.1190@gmail.com")); // period in local part
+        assertTrue(Email.isValidEmail("PeterJack+1190@gmail.com")); // '+' symbol in local part
+        assertTrue(Email.isValidEmail("PeterJack-1190@gmail.com")); // hyphen in local part
+        assertTrue(Email.isValidEmail("a1+be.d@gmail.com")); // mixture of alphanumeric and special characters
+        assertTrue(Email.isValidEmail("peter_jack@gmail.com")); // long domain name
+        assertTrue(Email.isValidEmail("if.you.dream.it_you.can.do.it@gmail.com")); // long local part
     }
 
     @Test
     public void equals() {
-        Email email = new Email("valid@email");
+        Email email = new Email("dave@gmail.com");
 
         // same values -> returns true
-        assertTrue(email.equals(new Email("valid@email")));
+        assertTrue(email.equals(new Email("dave@gmail.com")));
 
         // same object -> returns true
         assertTrue(email.equals(email));
@@ -84,7 +82,7 @@ public class EmailTest {
         assertFalse(email.equals(5.0f));
 
         // different values -> returns false
-        assertFalse(email.equals(new Email("other.valid@email")));
+        assertFalse(email.equals(new Email("other.valid@gmail.com")));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
@@ -69,9 +69,9 @@ public class NameContainsKeywordsPredicateTest {
         assertFalse(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
         // Keywords match phone, email and address, but does not match name
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("12345", "alice@email.com", "Main", "Street"));
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("12345", "alice@gmail.com", "Main", "Street"));
         assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345")
-                .withEmail("alice@email.com").withAddress("Main Street").build()));
+                .withEmail("alice@gmail.com").withAddress("Main Street").build()));
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -27,42 +27,42 @@ import seedu.address.model.person.Person;
 public class TypicalPersons {
 
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline")
-            .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
+            .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@gmail.com")
             .withPhone("94351253").withSalary("10000").withClaimBudget("5000").withDepartment("Engineering")
             .withDob("2000-01-01").withLeave("111101010101").build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25")
-            .withEmail("johnd@example.com").withPhone("98765432")
+            .withEmail("johnd@gmail.com").withPhone("98765432")
             .withSalary("100").withClaimBudget("5").withDepartment("Sales")
             .withDob("1997-05-05").withLeave("010101010101").build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
-            .withEmail("heinz@example.com").withAddress("wall street")
+            .withEmail("heinz@gmail.com").withAddress("wall street")
             .withSalary("1000000000000").withClaimBudget("500000").withDepartment("Executive")
             .withDob("1991-12-31").withLeave("000101010001").build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
-            .withEmail("cornelia@example.com").withAddress("10th street")
+            .withEmail("cornelia@gmail.com").withAddress("10th street")
             .withSalary("23232323232").withClaimBudget("19191919").withDepartment("Marketing")
             .withDob("1969-07-27").withLeave("111111111111").build();
     public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
-            .withEmail("werner@example.com").withAddress("michegan ave")
+            .withEmail("werner@gmail.com").withAddress("michegan ave")
             .withSalary("3000").withClaimBudget("200").withDepartment("HR")
             .withDob("1999-06-17").withLeave("000000000001").build();
     public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
-            .withEmail("lydia@example.com").withAddress("little tokyo")
+            .withEmail("lydia@gmail.com").withAddress("little tokyo")
             .withSalary("100000").withClaimBudget("1").withDepartment("Finance")
             .withDob("2002-02-27").withLeave("000000100000").build();
     public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")
-            .withEmail("anna@example.com").withAddress("4th street")
+            .withEmail("anna@gmail.com").withAddress("4th street")
             .withSalary("10000").withClaimBudget("5000").withDepartment("Engineering")
             .withDob("2005-09-30").withLeave("111111000000").build();
 
     // Manually added
     public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("8482424")
-            .withEmail("stefan@example.com").withAddress("little india")
+            .withEmail("stefan@gmail.com").withAddress("little india")
             .withSalary("10000").withClaimBudget("5000").withDepartment("Engineering")
             .withDob("2000-01-01").withLeave("000000000000").build();
     public static final Person IDA = new PersonBuilder().withName("Ida Mueller").withPhone("8482131")
-            .withEmail("hans@example.com").withAddress("chicago ave")
+            .withEmail("hans@gmail.com").withAddress("chicago ave")
             .withSalary("10000").withClaimBudget("5000").withDepartment("Engineering")
             .withDob("2000-01-01").withLeave("111000111000").build();
 


### PR DESCRIPTION
Modification of Email Validation Regex

The current codebase does not handle email inputs properly and emails without a domain name can be accepted.

Hence, I have made the necessary changes to the validation regex such that only emails with gmail.com are accepted. This is in line with our project requirements as companies normally only have 1 domain name for their employees' email.